### PR TITLE
Avoid deprecated simple symbols in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src" "test" "env" "resources"]
  :deps    {org.clojure/data.json                           {:mvn/version "0.2.7"}
-           clj-http                                        {:mvn/version "3.10.0"}
+           clj-http/clj-http                               {:mvn/version "3.10.0"}
            com.cognitect/anomalies                         {:mvn/version "0.1.12"}
-           clj-time                                        {:mvn/version "0.15.2"}
+           clj-time/clj-time                               {:mvn/version "0.15.2"}
            }
 
  :aliases {
@@ -11,10 +11,10 @@
                                :sha "2d75eac719e3a0e2112958cbc23d8cbfce4690bf"}}
                  :main-opts ["-m" "mach.pack.alpha.skinny" "--no-libs"
                              "--project-path" "azure-api.jar"]}
-           :install {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :install {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                       :main-opts ["-m" "deps-deploy.deps-deploy" "install"
                                   "azure-api.jar"]}
-           :deploy {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
                                 "azure-api.jar"]}
            :nrepl {:extra-deps


### PR DESCRIPTION
Currently, for every `clj` invocation in a project that uses `com.ardoq/azure-api` as dependency, we receive these `DEPRECATED` messages: 

```
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (~/.gitlibs/libs/com.ardoq/azure-api/.../deps.edn)
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (~/.gitlibs/libs/com.ardoq/azure-api/.../deps.edn)
DEPRECATED: Libs must be qualified, change clj-http => clj-http/clj-http (~/.gitlibs/libs/com.ardoq/azure-api/.../deps.edn)
DEPRECATED: Libs must be qualified, change clj-time => clj-time/clj-time (~/.gitlibs/libs/com.ardoq/azure-api/.../deps.edn)
```

This pull request should

- Reduce the amount of text in stdout when we are using  `com.ardoq/azure-api` 
- Make the library future-proof, avoiding future removal of this feature.
